### PR TITLE
Fix @supports `backdrop-filter` media query

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -138,7 +138,7 @@ body > div {
 
 /* -- Media Queries -- */
 
-@supports ((backdrop-filter: saturate) and (backdrop-filter: brightness)) or ((-webkit-backdrop-filter: saturate) and (-webkit-backdrop-filter: brightness)) {
+@supports ((not ((backdrop-filter: saturate(1)) and (backdrop-filter: brightness(1)))) and (not ((-webkit-backdrop-filter: saturate(1)) and (-webkit-backdrop-filter: brightness(1))))) {
     #card {
         background-color: rgba(var(--color-base), .7);
     }


### PR DESCRIPTION
This mess of CSS supports selectors simply doesn't work. Replaced it with something that does.
https://github.com/VictorWesterlund/victorwesterlund.com/blob/750ae4a6cb5b14e7c2d5b2d94e84fdf5a7a1d76c/public/assets/css/style.css#L141

Firefox 79 doesn't support any backdrop filters so that is an excellent browser to test the positive match of this negative query. (Valid if the browser **doesn't** support any backdrop filters)

Tested in:
Result|Browser|Comment
--|--|--
✔️|Chrome 98|Supports `backdrop-filter` and ignores failover styles
✔️|Firefox 97|Doesn't support any backdrop-filter property and uses failover styles
✔️|Safari 15.1|Supports `-webkit-backdrop-filter` and ignores failover styles